### PR TITLE
Fix for Client Error: Bad Request

### DIFF
--- a/eero_adguard_sync/commands/sync.py
+++ b/eero_adguard_sync/commands/sync.py
@@ -64,6 +64,9 @@ class EeroAdGuardSyncHandler:
                     )
                 except HTTPError as e:
                     errors = [
+                        "id required",
+                        "client is nil",
+                        "invalid name",
                         "client already exists",
                         "another client uses the same id",
                     ]


### PR DESCRIPTION
This commit introduces new values for the errors array within the EeroAdGuardSyncHandler.create definition to account for valid responses back from the AGH [API](https://github.com/PleaseStopAsking/AdGuardHome/blob/master/internal/home/clients.go). In my specific scenario, a few of the machines within my Eero network were returning with odd names and the AGH API requests were failing but eag-sync was not capable of catching the actual response as the error list is hardcoded.